### PR TITLE
Updates glyph names for Glyphs

### DIFF
--- a/boxDrawing.py
+++ b/boxDrawing.py
@@ -1509,6 +1509,9 @@ if f is not None:
             f.lib['public.glyphOrder'] = newGlyphOrder
 
     if inGlyphs:
+        # Update glyph names to comply with Glyphs's standard.
+        for glyphName in generatedGlyphs:
+            Font.glyphs[glyphName].updateGlyphInfo()
         Font.enableUpdateInterface()
 
     print '\nDone.'


### PR DESCRIPTION
Glyph names were different from Glyphs's standard name. It's fine as it is, but better to stick to what Glyphs expects. glyph.updateGlyphInfo() updates glyph names based on Unicode values.