### PR TITLE
Add -fontforge flag to output UFO with FontForge comptatible glif names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Ignore generated UFO folders.
 *.ufo/
 
-# Ignore python runtime
+# Ignore python runtime.
 __pycache__
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore generated UFO folders.
+*.ufo/
+
+# Ignore python runtime
+__pycache__
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # boxDrawing.py
 
-Soon after the first public release of [Source Code Pro][scp], users noted a lack of [Box Drawing Characters][boxwiki]. 
-Fortunately, this flaw could be remedied soon after—the whole set of Box Drawing Characters, plus all of the Block Elements are now part of Source Code Pro.  
+Soon after the first public release of [Source Code Pro][scp], users noted a lack of [Box Drawing Characters][boxwiki].
+Fortunately, this flaw could be remedied soon after—the whole set of Box Drawing Characters, plus all of the Block Elements are now part of Source Code Pro.
 
 [Source Code Pro][scp] is a typeface family intended for both programmers and designers. It has a fairly wide range of weights, therefore it was agreed to adjust the Box Drawing Characters in their stem widths, to make for a better corresponding appearance.
-The reasoning behind this decision is that everyone will benefit: The programmer will like the screen display adjusted to the chosen text weight. 
+The reasoning behind this decision is that everyone will benefit: The programmer will like the screen display adjusted to the chosen text weight.
 The graphic designer will appreciate a multitude of combination possibilities; and an unseen dynamic range of drawing boxes.
 
 All that is why this script was written. Drawing those generic glyphs by hand is not an amazing or creativity-challenging task. Much more fun is derived from modifying a script, which is capable of generating the most unexpected variations of Box Drawing Characters—over and over.
@@ -12,9 +12,9 @@ All that is why this script was written. Drawing those generic glyphs by hand is
 
 ## What does this script do?
 
-This script will draw the complete ranges of [Box Drawing Characters (`U+2500`–`U+257F`)][box] and [Block Elements (`U+2580`–`U+259F`)][block] in the font editor of your choice.  
-The design of those characters is based on a handful of parameters, which can be changed in the script file itself. 
-Feel free to create Box Drawing Characters that are longer than usual; exceedingly wide, fat (both?); or hairline-thin.  
+This script will draw the complete ranges of [Box Drawing Characters (`U+2500`–`U+257F`)][box] and [Block Elements (`U+2580`–`U+259F`)][block] in the font editor of your choice.
+The design of those characters is based on a handful of parameters, which can be changed in the script file itself.
+Feel free to create Box Drawing Characters that are longer than usual; exceedingly wide, fat (both?); or hairline-thin.
 
 
 Time was spent to make this script compatible with the triumvirate of commercial font editing applications; this means that this script will run in [RoboFont][], [Glyphs][], ~and even [FontLab][]~ without any modifications. It is also possible to run the script straight from the command line, which will generate a new [UFO file][ufo] right to your desktop.
@@ -22,23 +22,23 @@ Time was spent to make this script compatible with the triumvirate of commercial
 _(NB: FontLab 5 can no longer be tested because macOS 10.15 does not run 32-bit applications)._
 
 
-__Tested versions:__  
+__Tested versions:__
 Robofont: Version Version 3.4b (build 2003232105)
 Glyphs: Version 2.6.1 (1230)
 
 
-__Dependencies:__  
+__Dependencies:__
 
 - When using Glyphs or FontLab, [Robofab][] must be installed and working.
 
 - When using Glyphs, please make sure you have the [GSPen.py][] and [objectsGS.py][] modules installed.
 
-- When running the script from the command line, the [FontParts][] Python module must be installed.
+- When running the script from the command line, the [FontParts][] Python module must be installed (run `pip install -r requirements.txt`)
 
 
 ## What does this script not do?
 
-This script is not for adding Box Drawing Characters to existing, compiled fonts.  
+This script is not for adding Box Drawing Characters to existing, compiled fonts.
 It is assumed you have type design software, and font source data available; or at least know what to do with a [UFO file][ufo].
 
 
@@ -63,13 +63,13 @@ __Box Drawing__ [Unicode range 2500-257F][box] and __Block Elements__ [Unicode r
 Both Box Drawing Characters and Block Elements are mostly at home in the world of text-based UI; you might remember brilliant examples from MS-DOS Defrag or ScanDisk.
 
 	    ┌─┬────────────┐
-	┌───┘ │ Beautiful  │  
+	┌───┘ │ Beautiful  │
 	│     │ box.       │  ┌────────────╖
 	│     ╰─┰──────────┤  │ Another    ╟┐
 	│       ┃ The same │  │ quite nice ║│
 	│       ┃ ole box. │  │ box.       ║│
 	└───────┸──────────┘  ╘╤═══════════╝│
-	                       └────────────┘       
+	                       └────────────┘
 
 Box Drawing Characters can also be used for graphic design.
 As an example, see the “source code” (pun) of the [Adobe Type Team holiday card 2012][xmas]:
@@ -94,7 +94,7 @@ As an example, see the “source code” (pun) of the [Adobe Type Team holiday c
 	   ╶═╝┎┘│━┵┼┶━│┈╢TEAM<╯
 	   ╺━│┃░▒▓▌!▐▓▒░┃││┼☑┘╳
 
-	
+
 The [Project Page][] has some more examples for Box Drawing Characters in use (using Source Code Pro as a web font).
 
 
@@ -109,6 +109,12 @@ __Alternate method:__
 
 - Run the script on the command line.
 - A UFO full of Box Drawing Characters is created (given that [FontParts][] is installed and working).
+
+If you are planning to import the UFO into FontForge (for example, to merge it with another font), use the `-fontforge` command line argument to output compatible glif names based on Unicode values.
+
+```
+python boxDrawing.py -fontforge
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ __Dependencies:__
 
 - When using Glyphs, please make sure you have the [GSPen.py][] and [objectsGS.py][] modules installed.
 
-- When running the script from the command line, the [FontParts][] Python module must be installed (run `pip install -r requirements.txt`)
+- When running the script from the command line, the [FontParts][] Python module must be installed (run `pip install -r requirements.txt`).
 
 
 ## What does this script not do?

--- a/boxDrawing.py
+++ b/boxDrawing.py
@@ -50,6 +50,7 @@ IN_RF = False
 IN_FL = False
 IN_GLYPHS = False
 IN_SHELL = False
+FOR_FONTFORGE = False
 
 if not any((IN_RF, IN_FL, IN_GLYPHS)):
     try:
@@ -75,8 +76,14 @@ if not any((IN_RF, IN_FL, IN_GLYPHS)):
 if not any((IN_RF, IN_FL, IN_GLYPHS)):
     IN_SHELL = True
     import os
+    import sys
     import time
     from fontParts.fontshell import RFont
+
+    # Parse command line args.
+    for arg in sys.argv:
+        if arg.lstrip("-").lower() == "fontforge":
+            FOR_FONTFORGE = True
 
 
 if IN_GLYPHS:
@@ -872,12 +879,17 @@ if f is not None:
     # Keeping track of the glyph order
 
     for name, uni in sorted(recipes, key=lambda x: int(x[1], 16)):
+        # Set name of outputted glif.
+        glifname = name
+        if FOR_FONTFORGE:
+            glifname = "uni%s" % uni
+
         # sorting the dictionary by the Unicode value of the glyph.
         generatedGlyphs.append(name)
         commands = recipes[name, uni]
         print(name)
 
-        g = f.newGlyph(name, clear=True)
+        g = f.newGlyph(glifname, clear=True)
         g.width = WIDTH
         boxPen = g.getPen()
         for command in commands:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# Requirements for running from the command line.
+fontParts


### PR DESCRIPTION
I tried to import the UFO outputted from the command line into FontForge, however it did not recognize any of the glif names and added them as custom glyphs.

This change adds a command line argument to output glif names based on unicode values, which then imports correctly into FontForge.

I also added a requirements.txt file and updated the README to help make this a little easier for future new-comers.